### PR TITLE
Resolve PR comments for `fix: parser fails with older scoped packages`

### DIFF
--- a/packages/utils/src/miscellany.ts
+++ b/packages/utils/src/miscellany.ts
@@ -30,11 +30,8 @@ export function unmangleScopedPackage(packageName: string): string | undefined {
   return packageName.includes(separator) ? `@${packageName.replace(separator, "/")}` : undefined;
 }
 
-export function removeVersionFromPackageName(packageName:string | undefined): string | undefined {
-	const firstSlash = packageName?.indexOf("/");
-	const lastSlash = packageName?.lastIndexOf("/");
-
-	return packageName && firstSlash !== lastSlash ? packageName.slice(firstSlash, lastSlash) : packageName;
+export function removeVersionFromPackageName(packageName: string | undefined): string | undefined {
+  return packageName?.replace(/\/v(\d){1,}$/i, "");
 }
 
 export async function sleep(seconds: number): Promise<void> {

--- a/packages/utils/test/miscellany.test.ts
+++ b/packages/utils/test/miscellany.test.ts
@@ -1,0 +1,28 @@
+import { removeVersionFromPackageName, unmangleScopedPackage } from "../src/miscellany";
+
+describe("miscellany", () => {
+  describe(unmangleScopedPackage, () => {
+    it("for unscoped package returns undefined", () => {
+      expect(unmangleScopedPackage("foobar")).toBeUndefined();
+      expect(unmangleScopedPackage("utils")).toBeUndefined();
+    });
+
+    it("for scoped package returns unmangled name", () => {
+      expect(unmangleScopedPackage("foo__bar")).toBe("@foo/bar");
+      expect(unmangleScopedPackage("definitelytyped__utils")).toBe("@definitelytyped/utils");
+    });
+  });
+
+  describe(removeVersionFromPackageName, () => {
+    it("for non versioned package returns package", () => {
+      expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils")).toBe("@ckeditor/ckeditor5-utils");
+      expect(removeVersionFromPackageName("@foo/bar")).toBe("@foo/bar");
+    });
+
+    it("for versioned package returns package name only", () => {
+      expect(removeVersionFromPackageName("@ckeditor/ckeditor5-utils/v10")).toBe("@ckeditor/ckeditor5-utils");
+      expect(removeVersionFromPackageName("@foo/bar/v0")).toBe("@foo/bar");
+      expect(removeVersionFromPackageName("@foo/bar/V999")).toBe("@foo/bar");
+    });
+  });
+});


### PR DESCRIPTION
- add test coverage
- simplify implementation

/cc @fedemp 